### PR TITLE
Update Sphinx to Version 4.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.2" %}
+{% set version = "4.2.0" %}
 
 package:
   name: sphinx
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/Sphinx/Sphinx-{{ version }}.tar.gz
-  sha256: b5c2ae4120bf00c799ba9b3699bc895816d272d120080fbc967292f29b52b48c
+  sha256: 94078db9184491e15bce0a56d9186e0aec95f16ac20b12d00e06d4e36f1058a6
 
 build:
   number: 0


### PR DESCRIPTION
1. check the upstream
2. check the pinnings
 update: 
 https://github.com/sphinx-doc/sphinx/blob/v4.2.0/setup.py
 sphinxcontrib-htmlhekp >=2.0.0
 sphinxcontrib-serializinghtml >=1.1.5
 pygments >=2.0
 
3. check changelogs
https://github.com/sphinx-doc/sphinx/blob/v4.2.0/CHANGES

There were some important changes on the recipe

Release 4.1.2 (released Jul 27, 2021)
=====================================

Incompatible changes
--------------------
* #9435: linkcheck: Disable checking automatically generated anchors on
  github.com (ex. anchors in reST/Markdown documents)

Release 4.1.0 (released Jul 12, 2021)
=====================================

Deprecated
----------

* The ``app`` argument of ``sphinx.environment.BuildEnvironment`` becomes required
* ``sphinx.application.Sphinx.html_theme``
* ``sphinx.ext.autosummary._app``
* ``sphinx.util.docstrings.extract_metadata()``

The rest of the changes are new features or bug fixes

4. additional research
    open issues in conda-forge
    https://github.com/conda-forge/sphinx-feedstock/issues/107

    There is one open issue in conda-foorge related to importing files with the epub3 extensions

    The issue is already solved by the upstream
    https://github.com/sphinx-doc/sphinx/issues/9434

    The issue can be solved by updating the dependencies for `sphinxcontrib-htmlhelp` and `sphinxcontrib-serializinghtml`

    Since the upstream has known solutions for them, we can consider the issue resolved, but must keep an eye just in case

it is important to note that noarch packages sphinxcontrib-htmlhekp >=2.0.0 and sphinxcontrib-serializinghtml >=1.1.5 are already present.

5. verify dev_url
6. verify doc_url
7. verify that pip is checked
8. verify that wheel is available
9. verify the test section
10. additional tests

    In order to test the `sphinx` package the following command was use:
    `conda-build sphinx-feedstock --test`

    the result for the test was as follows:
    `All tests passed`

    In order to test the `sphinx` package we used the `altair` package to see if `sphinx` can be imported as a dependency. 
    The pinnings for `altair` were modified to add version `4.8.1` for `sphinx`. 
    
    The command used for testing was as follows: 
    `conda-build altair-feedstock --test`
    The test result were the following:
    `All tests passed`

We can conclude based on the results of the research, and on the results of the tests that it is relatively safe to update to version `4.8.1`