### PR TITLE
sphinx 4.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.2.0" %}
+{% set version = "4.4.0" %}
 
 package:
   name: sphinx
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/Sphinx/Sphinx-{{ version }}.tar.gz
-  sha256: 94078db9184491e15bce0a56d9186e0aec95f16ac20b12d00e06d4e36f1058a6
+  sha256: 6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
+{% set name = "sphinx" %}
 {% set version = "4.4.0" %}
 
 package:
-  name: sphinx
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/S/Sphinx/Sphinx-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Sphinx-{{ version }}.tar.gz
   sha256: 6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -20,8 +21,9 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
     - wheel
     - babel
   run:
@@ -30,19 +32,18 @@ requirements:
     - babel >=1.3
     - docutils >=0.14,<0.18
     - imagesize
+    - importlib-metadata >=4.4
     - jinja2 >=2.3
     - packaging
     - pygments >=2.0
-    - python
     - requests >=2.5.0
-    - setuptools
     - snowballstemmer >=1.1
     - sphinxcontrib-applehelp
     - sphinxcontrib-devhelp
-    - sphinxcontrib-htmlhelp
+    - sphinxcontrib-htmlhelp >=2.0.0
     - sphinxcontrib-jsmath
     - sphinxcontrib-qthelp
-    - sphinxcontrib-serializinghtml
+    - sphinxcontrib-serializinghtml >=1.1.5
     # only _strictly_ a windows dependency, but appeases `pip check`
     - colorama >=0.3.5
 
@@ -52,12 +53,16 @@ test:
     - sphinx.builders
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
-    - sphinx-quickstart --version
+    - sphinx-build --help
+    - sphinx-quickstart --help
+    - sphinx-apidoc --help
+    - sphinx-autogen --help
 
 about:
-  home: http://www.sphinx-doc.org
+  home: https://www.sphinx-doc.org
   license: BSD-2-Clause
   license_file: LICENSE
   license_family: BSD
@@ -68,7 +73,7 @@ about:
     It was originally created for the new Python documentation, and it has excellent
     facilities for the documentation of Python projects, but C/C++ is already supported
     as well, and it is planned to add special support for other languages as well.
-  doc_url: http://www.sphinx-doc.org/en/stable/contents.html
+  doc_url: https://www.sphinx-doc.org/en/stable/contents.html
   dev_url: https://github.com/sphinx-doc/sphinx
 
 extra:


### PR DESCRIPTION
Update sphinx to 4.4.0

Bug Tracker: new open issues https://github.com/sphinx-doc/sphinx/issues
Github releases:  https://github.com/sphinx-doc/sphinx/releases
License file:  https://github.com/sphinx-doc/sphinx/blob/v4.4.0/LICENSE
Upstream Changelog: features and bugfixes https://github.com/sphinx-doc/sphinx/blob/v4.4.0/CHANGES
Upstream setup.py:  https://github.com/sphinx-doc/sphinx/blob/v4.4.0/setup.py

The package sphinx is mentioned inside the packages:
alabaster | altair | altair3_2 | altiar | celery | git-cola | jira | mayavi | neon | numpydoc | pyaudio | recommonmark | sphinxcontrib-applehelp | sphinxcontrib-devhelp | sphinxcontrib-htmlhelp | sphinxcontrib-jsmath | sphinxcontrib-qthelp | sphinxcontrib-serializinghtml | sphinxcontrib-websupport | sphinx_rtd_theme | spyder | 

Actions:
1. Use jinja2 templates in urls
2. Reset build number to `0`
3. Fix python in `host` and `test/requires`
4. Add `setuptools` in `host`
5. Add `importlib-metadata >=4.4` in `run`
6. Remove duplicate `python` from `run` and remove `setuptools` from `run`
7. Update dependencies in `run`: `sphinxcontrib-htmlhelp >=2.0.0` and `sphinxcontrib-serializinghtml >=1.1.5`
8. Update test/commands:  add the next:
```
    - sphinx-build --help
    - sphinx-quickstart --help
    - sphinx-apidoc --help
    - sphinx-autogen --help
```
9. Use `https` in home and doc urls

Result:
- all-succeeded